### PR TITLE
[FIX] rend les choix des menu insensible a la case

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ def clean():
 def choix():
     print("""taper aide pour consulter les actions disponibles, taper indice pour avancer dans le scénario""")
     choix = input("Que faites vous ?")
-    return choix
+    return choix.lower()
 
 #
 quitter = False


### PR DESCRIPTION
Les options d'action QUITTER et TOPOLOGIE sont affichées en majuscule, mais testé en minuscule.
La solution proposée est de rendre les conditions insensibles à la case en appliquant lower() aux inputs utilisateur.